### PR TITLE
Fluid iframes, https-fix, plexrequests, code cleanup and fix incorrect data-content of Glances menu-item.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,11 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="shortcut icon" type="image/ico" href="favicon.ico" />
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.0/css/bootstrap.min.css" /> <!-- Bootstrap -->
-	<link href='http://fonts.googleapis.com/css?family=PT+Sans:400' rel='stylesheet' type='text/css'> <!-- Font -->
+	<link href='//fonts.googleapis.com/css?family=PT+Sans:400' rel='stylesheet' type='text/css'> <!-- Font -->
 	<link rel="stylesheet" href="css/reset.css"> <!-- CSS reset -->
 	<link rel="stylesheet" href="css/style.css"> <!-- Resource style -->
 	<script src="js/modernizr.js"></script> <!-- Modernizr -->
-  	
+
 	<title>Managethis</title>
 </head>
 
@@ -24,8 +24,9 @@
 		<li><a data-content="NZBGet" href="#0"><span class="glyphicon glyphicon-save"></span> NZBGet</a></li>
 		<li><a data-content="PlexPy" href="#0"><span class="glyphicon glyphicon-tasks"></span> PlexPy</a></li>
 		<li><a data-content="PlexPy" href="#0"><span class="glyphicon glyphicon-dashboard"></span> Glances</a></li>
+		<li><a data-content="PlexRequests" href="#0"><span class="glyphicon glyphicon-bullhorn"></span> Plex Requests</a></li>
 		<li><a data-content="Plex" href="#0"><span class="glyphicon glyphicon-play"></span> Plex</a></li>
-		</ul> 
+		</ul>
 	</nav>
 
 	<ul class="cd-tabs-content"> <!-- Replace URLs with your apps/Change height px-->
@@ -41,7 +42,7 @@
 		<iframe scrolling=auto src="<replace this>" style="width:100%; height:926px"></iframe>
 		</li>
 
-                <li data-content="Headphones">
+		<li data-content="Headphones">
 		<iframe scrolling=auto src="<replace this>" style="width:100%; height:926px"></iframe>
 		</li>
 
@@ -50,12 +51,17 @@
 		</li>
 
 		<li data-content="PlexPy">
-		<iframe scrolling=auto src="<replace this>/" style="width:100%; height:926px"></iframe>
-                </li>
-                
-                <li data-content="Glances">
+		<iframe scrolling=auto src="<replace this>" style="width:100%; height:926px"></iframe>
+        </li>
+
+        <li data-content="Glances">
 		<iframe scrolling=auto src="<replace this>" style="width:100%; height:926px"></iframe>
 		</li>
+
+        <li data-content="PlexRequests">
+		<iframe scrolling=auto src="<replace this>" style="width:100%; height:926px"></iframe>
+		</li>
+
 
 		<li data-content="Plex">
 		<iframe scrolling=auto src="<replace this>" style="width:100%; height:926px"></iframe>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 		<li><a data-content="Headphones" href="#0"><span class="glyphicon glyphicon-headphones"></span> Headphones</a></li>
 		<li><a data-content="NZBGet" href="#0"><span class="glyphicon glyphicon-save"></span> NZBGet</a></li>
 		<li><a data-content="PlexPy" href="#0"><span class="glyphicon glyphicon-tasks"></span> PlexPy</a></li>
-		<li><a data-content="PlexPy" href="#0"><span class="glyphicon glyphicon-dashboard"></span> Glances</a></li>
+		<li><a data-content="Glances" href="#0"><span class="glyphicon glyphicon-dashboard"></span> Glances</a></li>
 		<li><a data-content="PlexRequests" href="#0"><span class="glyphicon glyphicon-bullhorn"></span> Plex Requests</a></li>
 		<li><a data-content="Plex" href="#0"><span class="glyphicon glyphicon-play"></span> Plex</a></li>
 		</ul>

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 jQuery(document).ready(function($){
 	var tabs = $('.cd-tabs');
-	
+
 	tabs.each(function(){
 		var tab = $(this),
 			tabItems = tab.find('ul.cd-tabs-navigation'),
@@ -14,11 +14,11 @@ jQuery(document).ready(function($){
 				var selectedTab = selectedItem.data('content'),
 					selectedContent = tabContentWrapper.find('li[data-content="'+selectedTab+'"]'),
 					slectedContentHeight = selectedContent.innerHeight();
-				
+
 				tabItems.find('a.selected').removeClass('selected');
 				selectedItem.addClass('selected');
 				selectedContent.addClass('selected').siblings('li').removeClass('selected');
-				//animate tabContentWrapper height when content changes 
+				//animate tabContentWrapper height when content changes
 				tabContentWrapper.animate({
 					'height': slectedContentHeight
 				}, 200);
@@ -27,17 +27,18 @@ jQuery(document).ready(function($){
 
 		//hide the .cd-tabs::after element when tabbed navigation has scrolled to the end (mobile version)
 		checkScrolling(tabNavigation);
-		tabNavigation.on('scroll', function(){ 
+		tabNavigation.on('scroll', function(){
 			checkScrolling($(this));
 		});
 	});
-	
+
 	$(window).on('resize', function(){
 		tabs.each(function(){
 			var tab = $(this);
 			checkScrolling(tab.find('nav'));
 			tab.find('.cd-tabs-content').css('height', 'auto');
 		});
+		resizeIframe(); // Resize iframes when window is resized.
 	});
 
 	function checkScrolling(tabs){
@@ -49,4 +50,15 @@ jQuery(document).ready(function($){
 			tabs.parent('.cd-tabs').removeClass('is-ended');
 		}
 	}
+
+	// Measure viewport and subtract the height the navigation tabs, then resize the iframes.
+	function resizeIframe(){
+		var newSize = $(window).height() - $('.cd-tabs').height();
+        $('iframe').css({ 'height': newSize + 'px' });
+	}
+
+// Call resizeIframe when document is ready
+resizeIframe();
+
+
 });

--- a/js/main.js
+++ b/js/main.js
@@ -53,7 +53,7 @@ jQuery(document).ready(function($){
 
 	// Measure viewport and subtract the height the navigation tabs, then resize the iframes.
 	function resizeIframe(){
-		var newSize = $(window).height() - $('.cd-tabs').height();
+		var newSize = $(window).height() - $('nav').height();
         $('iframe').css({ 'height': newSize + 'px' });
 	}
 


### PR DESCRIPTION
Added function to measure height of viewport and subtract the height of
the navigation tabs and then resize the iframes based on that (so that
the iframes always cover the entire height of the viewport without
causing scrollbars).

Also removed "http://" from Google Fonts URL, which breaks https
(unsecured resources). Replaced with simply "//", which works in both
cases.

Also added Plex Requests link, and fixed incorrect data-content of Glances (if you clicked it, it showed PlexPy).
