### PR TITLE
Doubleclicking a menu item will reload that specific applications iframe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a lightweight way to manage your HTPC apps without having to run anythin
 - Now edit the parts marked as "replace me" with the urls of your apps.
 - Change the icons by replacing them with ones from http://bootstrapdocs.com/v3.0.0/docs/components/
 - Navigate to http://youripaddress/Managethis to access it.
+- To reload an app, double click it in the menu. Only that specific page will reload.
 
 You may want to setup htaccess to secure it but even if you don't your apps will not be accessible as long as they themselves are secure.
 

--- a/js/main.js
+++ b/js/main.js
@@ -15,6 +15,10 @@ jQuery(document).ready(function($){
 					selectedContent = tabContentWrapper.find('li[data-content="'+selectedTab+'"]'),
 					slectedContentHeight = selectedContent.innerHeight();
 
+				selectedItem.dblclick(function() {
+					selectedContent.children('iframe').attr('src', selectedContent.children('iframe').attr('src'));
+				})
+
 				tabItems.find('a.selected').removeClass('selected');
 				selectedItem.addClass('selected');
 				selectedContent.addClass('selected').siblings('li').removeClass('selected');
@@ -54,11 +58,9 @@ jQuery(document).ready(function($){
 	// Measure viewport and subtract the height the navigation tabs, then resize the iframes.
 	function resizeIframe(){
 		var newSize = $(window).height() - $('nav').height();
-        $('iframe').css({ 'height': newSize + 'px' });
+		$('iframe').css({ 'height': newSize + 'px' });
 	}
 
 // Call resizeIframe when document is ready
 resizeIframe();
-
-
 });


### PR DESCRIPTION
This is useful if for example ruTorrent is acting up, or if CouchPotato is having some problem and you want to reload only that application without having to reload everything.

I opted to make it a double-click, instead of adding an icon for it, which would take up precious space.
